### PR TITLE
Add a command to allow players to toggle the messages

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -18,7 +18,7 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
     USA
 ]]
-
+local S = core.get_translator("random_messags_api")
 random_messages_api = {
     list = {},
     interval = tonumber(minetest.settings:get("random_messages_api.interval") or 60) or 60,
@@ -73,18 +73,18 @@ end
 
 minetest.register_chatcommand("toggle_random_messages", {
     params = "",
-    description = "Toggle whether to show the random messages to you",
+    description = S("Toggle whether to show the random messages to you"),
     privs = {},
     func = function(name, param)
         if not minetest.settings:get_bool("random_messages_api.allow_hiding_messages", true) then
-            return false, "This functionality has been disabled by the server."
+            return false, S("This functionality has been disabled by the server.")
         end
         local player = minetest.get_player_by_name(name)
         if not player then return end    
         local meta = player:get_meta()
         local is_hidden = (meta:get_int("hide_random_messages") == 1)
         meta:set_int("hide_random_messages",not is_hidden and 1 or 0)
-        return true, "Random messages are now "..(is_hidden and "shown to you." or "hidden from you.")
+        return true, is_hidden and S("Random messages are now shown to you.") or S("Random messages are now hidden from you.")
     end
 })
 
@@ -94,11 +94,9 @@ local function loop()
     if msg then
         for _, player in ipairs(minetest.get_connected_players()) do
             local name = player:get_player_name()
-            if force_show_messages then 
-                minetest.chat_send_player(name, minetest.get_color_escape_sequence("grey") .. msg)
-            elseif not (minetest.global_exists("afk_indicator")
+            if not (minetest.global_exists("afk_indicator")
                 and afk_indicator.get(name) > 300) -- don't worry about sending messages to afk players
-                and player:get_meta():get_int("hide_random_messages") ~= 1 then -- check per-player config
+                and (force_show_messages or player:get_meta():get_int("hide_random_messages") ~= 1) then -- check per-player config
                 minetest.chat_send_player(name, minetest.get_color_escape_sequence("grey") .. msg)
             end
         end

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -5,3 +5,8 @@ random_messages_api.interval (Random announcement interval) int 60
 # Write one messages per line.
 # Blank lines or lines starting with an hash are ignored.
 random_messages_api.load_custom_messages (Load custom messages) bool true
+
+# Allow players to toggle whether they are shown random announcements
+# Experienced players may not need constant reminders on how to play
+# Defaults to showing messages for new players
+random_messages_api.allow_hiding_messages (Allow hiding messages) bool true


### PR DESCRIPTION
 - Allow hiding the messages on a per-player basis
 - Server setting to force players to see the messages, regardless of whether they have toggled them on or off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /toggle_random_messages so players can individually toggle random announcement visibility.
  * Added server setting to enable/disable per-player message hiding.
  * Message delivery now respects AFK status and each player's hide preference, so messages are sent only to applicable players.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->